### PR TITLE
Clean PKGBUILD to build only csvkit

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,40 +3,28 @@
 # Contributor: Thor K. H. <thor alfakrøll roht dott no>
 
 pkgname=csvkit-git
-pkgver=0.9.1.r280.g48f9602
-pkgrel=3
+pkgver=0.9.1.r319.gea1e7bb
+pkgrel=4
 pkgdesc="A suite of utilities for converting to and working with CSV."
 arch=('any')
 url="http://csvkit.readthedocs.org"
 license=('MIT')
 depends=(
     'python'
-    'python-xlrd' # >=0.9.4 for csvkit and agate
     'python-dateutil' # >=2.2
     'python-sqlalchemy' # >=0.9.3
-    'python-openpyxl' # >=2.0.3 for csvkit and agate
-    'python-six' # >=1.6.1 for csvkit and agate
-    'python-isodate' # >= 0.5.4 for agate
-    'python-parsedatetime' # >=1.5 for agate
-    'python-pytimeparse' # >= 1.1.5 for agate
+    'python-six' # >=1.6.1
+    'python-agate' # >= 1.2.2
+    'python-agate-excel' # >= 0.1.0
+    'python-agate-dbf' # >= 0.1.0
 )
 makedepends=(
     'git'
     'python-setuptools'
     'python-pip'
 )
-md5sums=(
-    'SKIP'
-    'SKIP'
-    'SKIP'
-    'SKIP'
-)
-source=(
-    'csvkit::git://github.com/wireservice/csvkit.git'
-    'agate::git://github.com/wireservice/agate.git'
-    'agate-excel::git://github.com/wireservice/agate-excel.git'
-    'agate-dbf::git://github.com/wireservice/agate-dbf.git'
-)
+md5sums=('SKIP')
+source=('csvkit::git://github.com/wireservice/csvkit.git')
 
 pkgver() {
   cd "$srcdir/csvkit"
@@ -53,23 +41,6 @@ build() {
 
 package() {
   cd "$srcdir/csvkit"
-  python setup.py install --root="$pkgdir/"
-
-  cd "$srcdir/agate"
-  python setup.py install --root="$pkgdir/"
-  PYTHON_MINOR_VERSION=`python --version | cut -d ' ' -f 2 | cut -d '.' -f -2`
-  ADDREGATIONS_DIR="$pkgdir/usr/lib/python$PYTHON_MINOR_VERSION/site-packages/agate/aggregations"
-  test -d "$AGGREGATIONS_DIR" || cp --recursive "$srcdir/agate/agate/aggregations" "$ADDREGATIONS_DIR"
-
-  cd "$srcdir/agate-excel"
-  python setup.py install --root="$pkgdir/"
-
-  cd "$srcdir/agate-dbf"
-  python setup.py install --root="$pkgdir/"
-
-  test -d "$srcdir/tmp" || mkdir "$srcdir/tmp"
-  #chmod +r "$pkgdir"
-  TMPDIR="$srcdir/tmp" pip install 'Babel>=2.0' dbfread --root "$pkgdir/"
-  TMPDIR="$srcdir/tmp" pip install 'dbfread>=2.0.5' --root "$pkgdir/"
+  python setup.py install --root="$pkgdir/" --optimize=1
 }
 


### PR DESCRIPTION
I've created the following PKGBUILDs and uploaded them to AUR:
- agate: https://aur.archlinux.org/packages/python-agate/
- agate-dbf: https://aur.archlinux.org/packages/python-agate-dbf/
- agate-excel: https://aur.archlinux.org/packages/python-agate-excel/
- awesome-slugify: https://aur.archlinux.org/packages/python-awesome-slugify/
- dbfread: https://aur.archlinux.org/packages/python-dbfread/

So, the PKGBUILD for csvkit can be simplified a lot.
